### PR TITLE
이중인증 및 계정삭제 이벤트리스너 추가

### DIFF
--- a/js/pages/myPage/Mypage.js
+++ b/js/pages/myPage/Mypage.js
@@ -105,9 +105,9 @@ export default class extends AbstractView {
           </form>
         </div>
         <div id="myPageBtnsSection">
-          <button class="myPageSettingBtns">Two-factor authentication</button>
-          <button class="myPageSettingBtns">logout</button>
-          <button class="myPageSettingBtns">delete account</button>
+          <button id="twoFactorAuthButton" class="myPageSettingBtns">Two-factor authentication</button>
+          <button id="logoutButton" class="myPageSettingBtns">logout</button>
+          <button id="deleteAccountButton" class="myPageSettingBtns">delete account</button>
         </div>
         <button id="myPageSettingUpdateBtn">update</button>
       </div>
@@ -303,6 +303,42 @@ export default class extends AbstractView {
     await checkConnectionSocket(this.socketEventHandler.bind(this));
     this.updateUserProfile();
     this.myPageSettingModalEvent();
+    const accessToken = getToken();
+    
+    // Two-factor authentication 버튼에 대한 이벤트 리스너 추가
+    const twoFactorAuthButton = document.querySelector('#twoFactorAuthButton');
+    twoFactorAuthButton.addEventListener('click', function() {
+        // 인증 페이지로 리다이렉트
+        window.location.href = './verify_code.html';
+    });
+
+    // Delete account 버튼에 대한 이벤트 리스너 추가
+    const deleteAccountButton = document.querySelector('#deleteAccountButton');
+    deleteAccountButton.addEventListener('click', async () => {
+        const confirmed = confirm('Are you sure you want to delete your account? This action cannot be undone.');
+        if (confirmed) {
+            try {
+                const response = await fetch('http://localhost:8000/tcen-auth/delete/', {
+                    method: 'DELETE',
+                    headers: {
+                        'Authorization': `Bearer ${accessToken}`,
+                        'Content-Type': 'application/json'
+                    },
+                });
+                if (response.ok) {
+                    alert('Account deleted successfully.');
+                    // 여기에 계정 삭제 후 처리 로직 추가, 예: 로그아웃, 홈페이지로 리다이렉트 등
+                    window.location.href = 'http://localhost:5500'; 
+                } else {
+                    console.error('Failed to delete account.');
+                    alert('Failed to delete account.');
+                }
+            } catch (error) {
+                console.error('Error:', error);
+                alert('An error occurred while deleting the account.');
+            }
+        }
+    });
   }
   
   async socketEventHandler(message) {

--- a/js/pages/two_factor/verify_code.js
+++ b/js/pages/two_factor/verify_code.js
@@ -1,0 +1,53 @@
+import { getToken } from '../../tokenManager.js';
+
+document.getElementById('sendEmailButton').addEventListener('click', async function() {
+    const accessToken = getToken(); // 액세스 토큰 가져오기
+    try {
+        // 이메일 발송을 위한 GET 요청
+        const response = await fetch('http://localhost:8000/tcen-auth/verify/', {
+            method: 'GET',
+            //credentials: 'include', // 쿠키를 포함하여 요청
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+                'Content-Type': 'application/json'
+            },
+        });
+        if (response.ok) {
+            alert('Authentication email sent successfully.');
+        } else {
+            console.error('Failed to send email.');
+        }
+    } catch (error) {
+        console.error('Error:', error);
+    }
+});
+
+document.getElementById('verifyCodeForm').addEventListener('submit', async function(e) {
+    e.preventDefault(); // 폼 기본 제출 방지
+
+    const code = document.getElementById('code').value;
+    const accessToken = getToken(); // 액세스 토큰 가져오기
+
+    try {
+        // 인증 코드 검증을 위한 POST 요청
+        const response = await fetch('http://localhost:8000/tcen-auth/verify/', {
+            method: 'POST',
+            //credentials: 'include',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ code: code }),
+        });
+
+        if (response.ok) {
+            alert('Authentication successful');
+            // 인증 성공 후의 로직 구현, 예: 페이지 리다이렉션
+        } else {
+            document.getElementById('error').textContent = 'Authentication failed';
+        }
+    } catch (error) {
+        console.error('Error:', error);
+        document.getElementById('error').textContent = 'An error occurred';
+    }
+});

--- a/js/tokenManager.js
+++ b/js/tokenManager.js
@@ -3,11 +3,11 @@ import {router} from './route.js';
 let accessToken = '';
 
 export const setToken = token => {
-  accessToken = token;
+  sessionStorage.setItem('access_token', token); // 세션 스토리지에 액세스 토큰 저장 TODO: check 필요
 };
 
 export const getToken = () => {
-  return accessToken;
+  return sessionStorage.getItem('access_token'); // 세션 스토리지에서 액세스 토큰 가져오기 TODO: check 필요
 };
 
 export const setRefreshToken = token => {

--- a/verify_code.html
+++ b/verify_code.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Verify Your Code</title>
+</head>
+<body>
+    <h1>Verify Your Authentication Code</h1>
+    <p style="color: red" id="error"></p>
+    <form id="verifyCodeForm">
+        <label for="code">Enter your authentication code:</label>
+        <input type="text" id="code" name="code" required />
+        <!-- 이메일 발송 버튼 추가 -->
+        <button id="sendEmailButton">Send Authentication Email</button>
+        <button type="submit">Verify</button>
+    </form>
+
+    <!-- 분리된 JavaScript 파일을 모듈로 불러옵니다. 경로는 실제 프로젝트 구조에 맞게 조정해야 합니다. -->
+    <script type="module" src="./js/pages/two_factor/verify_code.js"></script>
+</body>
+</html>


### PR DESCRIPTION
- access_token 세션스토리지에 저장하는 방식으로 변경
    
- 이중인증 버튼 클릭시 임시페이지로 리다이렉션

- 계정삭제 버튼시 이중인증을 거친 사용자면 db에서 해당 사용자 삭제 후 로그인 화면으로 리다이렉션